### PR TITLE
Updated to install with python3.7, fixed rate limiting issues.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.screepsas.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.5
+ENV FLASK_APP=screeps_loan/screeps_loan.py
+ENV SETTINGS=/app/settings
+WORKDIR /app
+COPY . /app
+RUN pip install -e .
+CMD ["screepsautospawner", "respawn"]

--- a/autospawner/screeps.py
+++ b/autospawner/screeps.py
@@ -18,11 +18,17 @@ if 'ptr' not in settings:
 if 'host' not in settings:
     settings['host']= None
 
-screepsclient = screepsapi.API(
-                u=settings['username'],
-                p=settings['password'],
-                ptr=settings['ptr'],
-                host=settings['host'])
+if 'token' in settings:
+    screepsclient = screepsapi.API(
+                    token=settings['token'],
+                    ptr=settings['ptr'],
+                    host=settings['host'])
+else:
+    screepsclient = screepsapi.API(
+                    u=settings['username'],
+                    p=settings['password'],
+                    ptr=settings['ptr'],
+                    host=settings['host'])
 
 def api_error_except(api_result):
     if 'error' in api_result:

--- a/autospawner/spawner.py
+++ b/autospawner/spawner.py
@@ -248,12 +248,10 @@ class RoomInfo:
             if 'user' in mapstats['stats'][room]['own']:
                 return False
 
-        #status_details = screepsclient.room_status(room, shard)['room']
-        #screepsclient.api_error_except(status_details)
-        # mapstats already has these details, use it rather than more api calls
         status_details = mapstats['stats'][room]
         if status_details['status'] != 'normal':
             return False
+
         # Some rooms seems to have openTime and novice times from the past, ignore those.
         if 'openTime' in status_details and float(status_details['openTime']) / 1000 > time():
             return False
@@ -261,12 +259,6 @@ class RoomInfo:
         if 'novice' in status_details and float(status_details['novice']) / 1000 > time():
             if self.getGcl() > 3:
                 return False
-
-        # Why check owner again? mapstats is accurate for that.
-        #overview = screepsclient.room_overview(room, shard=shard)
-        #screepsclient.api_error_except(overview)
-        #if overview['owner'] is not None:
-        #    return False
 
         return True
 

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     'click>=5.0,<6.0',
     'PyYAML>=3.12,<3.13',
     'requests>=2.18.0,<2.19',
-    'screepsapi>=0.4.3'
+    'screepsapi>=0.5.0'
   ],
 
   extras_require={

--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,8 @@ setup(
 
   install_requires=[
     'click>=5.0',
-    'PyYAML>=3.12',
-    'requests>=2.18.0',
+    'PyYAML>=3.12, <4.0',
+    'requests>=2.18.0, <3.0',
     'screepsapi>=0.5.0'
   ],
 

--- a/setup.py
+++ b/setup.py
@@ -42,9 +42,9 @@ setup(
   ],
 
   install_requires=[
-    'click>=5.0,<6.0',
-    'PyYAML>=3.12,<3.13',
-    'requests>=2.18.0,<2.19',
+    'click>=5.0',
+    'PyYAML>=3.12',
+    'requests>=2.18.0',
     'screepsapi>=0.5.0'
   ],
 


### PR DESCRIPTION
Updated to work with python 3.7 (Allowed newer versions of the packages)
Adjust room listing to reduce API calls.
- Was calling mapstats once per room, max is 60/hour, now calls mapstats once with all the rooms.
- Removed extra api calls that are unnecessary
- Allow for novice and openTime to exist but be in the past.